### PR TITLE
feat: generic dataset download support

### DIFF
--- a/dataset/download.py
+++ b/dataset/download.py
@@ -1,0 +1,99 @@
+import git
+from git import RemoteProgress
+from pathlib import Path
+from tqdm import tqdm
+
+# * Add repositories that should be downloaded to this dictionary
+# format for each entry should be:
+# name : (url to repo, branch, msg)
+# Use `None` for irrelevant entries.
+REPOSITORIES_TO_DOWNLOAD = {
+    "FFHQ": {
+        "LABELS": (  # Setup FFHQ labels
+            "https://github.com/DCGM/ffhq-features-dataset.git",
+            "master",
+            None,
+        ),
+        "IMAGES": {
+            256: (  # Setup FFHQ 256 images
+                None,
+                None,
+                "FFHQ 256 dataset instructions:\n"
+                "1. Download dataset from (must register account on Kaggle):\n"
+                + "https://www.kaggle.com/datasets/xhlulu/flickrfaceshq-dataset-nvidia-resized-256px?resource=download\n"
+                + "2. Unzip and place image files in directory:\n"
+                + "dataset/FFHQ_256/image",
+            ),
+        },
+    }
+}
+
+# Where to download repositories to
+ROOT = Path("dataset")
+
+
+def main():
+    """Downloads all repositories."""
+    tqdm.write("Downloading repositories...\n")
+    for name, label_image_dict in REPOSITORIES_TO_DOWNLOAD.items():
+        # Images
+        for res, (url, branch, msg) in label_image_dict["IMAGES"].items():
+            _setup_repos(url, _get_dataset_name(name, res) + "/image", branch, msg)
+
+        # Labels
+        if "LABELS" in label_image_dict:
+            url, branch, msg = label_image_dict["LABELS"]
+            _setup_repos(url, _get_dataset_labels_name(name), branch, msg)
+
+
+def _setup_repos(url, repo, branch, msg):
+    if url is None:
+        _setup_directory(ROOT / repo)
+    else:
+        output_path = ROOT / repo
+        if output_path.is_file():
+            raise RuntimeError(f"Download location occupied by file: '{output_path}'")
+        elif output_path.is_dir():
+            tqdm.write(f"Repository '{repo}' already downloaded, skipping...\n")
+        else:
+            git.Repo.clone_from(
+                url, ROOT / repo, progress=CloneProgress(repo), branch=branch
+            )
+    if msg is not None:
+        tqdm.write("-" * len(msg))
+        tqdm.write(msg)
+        tqdm.write("-" * len(msg))
+    tqdm.write("Done!")
+
+
+def _get_dataset_labels_name(name: str) -> str:
+    # Assumes sames labels for different resolutions
+    return "_".join([name, "LABELS"])
+
+
+def _get_dataset_name(name: str, res: int) -> str:
+    return "_".join([name, str(res)])
+
+
+def _setup_directory(dir_path: Path) -> None:
+    if dir_path.is_file():
+        RuntimeError(f"File found at {dir_path}, file should not exist.")
+    else:
+        dir_path.mkdir(parents=True, exist_ok=True)
+
+
+class CloneProgress(RemoteProgress):
+    """Progress logger for Git cloning."""
+
+    def __init__(self, repo: str):
+        super().__init__()
+        self._pbar = tqdm(desc=repo)
+
+    def update(self, op_code, cur_count, max_count=None, message=""):
+        self._pbar.total = max_count
+        self._pbar.n = cur_count
+        self._pbar.refresh()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dataset/FFHQDataset.py
+++ b/src/dataset/FFHQDataset.py
@@ -9,7 +9,6 @@ from tqdm import tqdm
 from multiprocessing import Pool, cpu_count
 import numpy as np
 from pathlib import Path
-
 from typing import List, Tuple
 
 _DEFAULT_RES = 256
@@ -33,8 +32,8 @@ class FFHQDataset(Dataset):
     # Subdirectory name to the images
     DS_DIR_IMAGES = "image/"
 
-    # Subdirectory name to the labels
-    DS_DIR_LABELS = "label/"
+    # Path to labels directory
+    DS_LABEL_PATH = Dataset.DS_DIR_PREFIX / "FFHQ_LABELS" / "json"
 
     # Filename of the extracted labels
     DS_LABELS_NAME = "labels.pkl"
@@ -101,7 +100,7 @@ class FFHQDataset(Dataset):
 
     def init_files(self) -> Tuple[FileJar, pd.DataFrame]:
         """
-        Initilizes the label files related to the dataset.
+        Initializes the label files related to the dataset.
         Extract labels from the dataset and saves them with a
         FileJar as well as a pd.DataFrame.
 
@@ -145,15 +144,14 @@ class FFHQDataset(Dataset):
                 a pd.DataFrame containing labels.
         """
         # Loop through all json files, save all filenames
-        label_dir_path = self.get_path() / self.DS_DIR_LABELS
-        if label_dir_path.is_dir():
+        if self.DS_LABEL_PATH.is_dir():
             json_files = [
                 pos_json
-                for pos_json in os.listdir(label_dir_path)
+                for pos_json in os.listdir(self.DS_LABEL_PATH)
                 if pos_json.endswith(".json")
             ]
         else:
-            raise FileNotFoundError(f"Directory {label_dir_path} not found!")
+            raise FileNotFoundError(f"Directory {self.DS_LABEL_PATH} not found!")
 
         # Create iterable object for multprocesssing work
         iter = [(index, json_f) for index, json_f in enumerate(json_files)]
@@ -204,9 +202,7 @@ class FFHQDataset(Dataset):
         json_f = args[1]
 
         # Parse json
-        with open(
-            os.path.join(self.get_path() / self.DS_DIR_LABELS, json_f)
-        ) as json_file:
+        with open(os.path.join(self.DS_LABEL_PATH, json_f)) as json_file:
             json_obj = json.load(json_file)
             if not json_obj:
                 return []


### PR DESCRIPTION
also:
- label path renaming and restructure in ffhq dataset

note:
- since labels are agnostic to resolution of the images, labels now reside outside of FFHQ_256, such that more variants of FFHQ can reach them.