### PR TITLE
feat: far compound metric

### DIFF
--- a/src/filter/DatasetSimilarityFilter.py
+++ b/src/filter/DatasetSimilarityFilter.py
@@ -27,6 +27,10 @@ class DatasetSimilarityFilter(SampleMetricFilter):
     def reg_setup_modes(self) -> dict[str, SetupMode]:
         return self.sample_metric_reg_setup_modes()
 
+    @staticmethod
+    def get_bit() -> int:
+        return 2
+
     def apply(smm: SampleMetricManager, **parameters: Any) -> pd.index:
         """
         Applies filter on population contained in given sample metric manager.
@@ -54,10 +58,11 @@ class DatasetSimilarityFilter(SampleMetricFilter):
             else False
         )
 
-        # Get metric value
-        ds_sim = smm.get(
-            [DatasetSimilaritySampleMetric.get_name()], calc_if_missing=True
-        ).astype(float)
+        # Calc metric value
+        smm.calc(
+            [DatasetSimilaritySampleMetric.get_name()],
+        )
+        ds_sim = smm.get([DatasetSimilaritySampleMetric.get_name()]).astype(float)
 
         # Get threshold
         threshold = (

--- a/src/filter/Filter.py
+++ b/src/filter/Filter.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 import pandas as pd
 import abc
-from typing import TYPE_CHECKING, Type, Any
+from typing import TYPE_CHECKING, Any
 from src.core.Setupable import Setupable
 
 if TYPE_CHECKING:
-    from src.filter.FilterRegistry import FilterRegistry
     from src.metric.SampleMetricManager import SampleMetricManager
 
 
@@ -41,23 +40,16 @@ class Filter(Setupable, metaclass=abc.ABCMeta):
 
         self._smm = smm
 
-    @classmethod
-    def get_bit(cls, filter_registry: Type[FilterRegistry]):
+    @staticmethod
+    @abc.abstractmethod
+    def get_bit() -> int:
         """
-        Returns the bit associated with the filter.
-
-        The order of the bits are analogous to the order of filters in the `filter_registry`.
-
-        Args:
-            filter_registry (Type[FilterRegistry]): The filter registry to infer ordering from.
+        Should return the bit associated with the filter.
 
         Returns:
             int: The bit representing this filter.
         """
-        filters = filter_registry.get_resources()
-        for id, filter in enumerate(filters):
-            if cls == filter:
-                return 1 << id
+        pass
 
     @staticmethod
     @abc.abstractmethod

--- a/src/filter/FilterRegistry.py
+++ b/src/filter/FilterRegistry.py
@@ -22,14 +22,11 @@ class FilterRegistry(Registry):
     Registry used for initialization and storing of all subclasses of the
     filter class.
 
-    Note that order of filter corresponds what bit in the bitmap
-    that filter is associated with.
-
     * If more filters are implemented they must be manually added
     to the internal storage (`_FILTERS`) of this class.
     """
 
-    _FILTERS = {  #! IdentityFilter must be the first entry in this list - do not change its location
+    _FILTERS = {
         IDENTITY_FILTER_NAME: IdentityFilter,
         DATASET_SIMILARITY_FILTER_NAME: DatasetSimilarityFilter,
         POPULATION_SIMILARITY_FILTER_NAME: PopulationSimilarityFilter,

--- a/src/filter/IdentityFilter.py
+++ b/src/filter/IdentityFilter.py
@@ -19,6 +19,10 @@ class IdentityFilter(Filter):
     def reg_setup_modes(self) -> dict[str, SetupMode]:
         return {}
 
+    @staticmethod
+    def get_bit() -> int:
+        return 1
+
     def apply(smm: SampleMetricManager):
         # Every sample passes
         return smm.get_population().get_data().index

--- a/src/metric/CompoundMetric.py
+++ b/src/metric/CompoundMetric.py
@@ -72,8 +72,7 @@ class CompoundMetric(Setupable, metaclass=abc.ABCMeta):
 
         Args:
             filter_bit (int, optional): Filter bit used to select a subset of the
-                population. Filter bit is defined by the order in FilterRegistry. For example,
-                the first filter corresponds to filter bit 1. Defaults to 1 (IdentityFilter).
+                population. Defaults to 1 (IdentityFilter).
             **parameters (Any): Arbitrary metric parameters.
 
         Returns:

--- a/src/metric/DatasetSimilaritySampleMetric.py
+++ b/src/metric/DatasetSimilaritySampleMetric.py
@@ -9,6 +9,7 @@ from src.metric.SampleMetric import SampleMetric
 
 if TYPE_CHECKING:
     from src.metric.SampleMetricManager import SampleMetricManager
+    from src.dataset.Dataset import Dataset
 
 DATASET_SIMILARITY_NAME = "DatasetSimilarity"
 
@@ -95,4 +96,26 @@ class DatasetSimilaritySampleMetric(SampleMetric):
             output[i] = np.sort(similarities)[-1]
 
         # Return similarity scores between samples and dataset
+        return output
+
+    @staticmethod
+    def dataset_vs_dataset_similarity(dataset: Dataset):
+        # Load dataset projections
+        dataset_projections = MS.load_projected_images(
+            dataset.get_name(dataset.get_resolution())
+        )
+
+        # Derive similarity scores and find largest per sample
+        output = np.zeros(dataset_projections.shape[0])
+        for i in tqdm(
+            range(dataset_projections.shape[0]), desc="Calculating similarity scores"
+        ):
+            # TODO: Make this using multiprocessing i.e. Pool and Map
+            similarities = (
+                dataset_projections[i, :].dot(dataset_projections.T).flatten()
+            )
+            similarities[i] = -float("inf")  # Do not check similarity with self
+            output[i] = np.sort(similarities)[-1]
+
+        # Return similarity scores between dataset and dataset
         return output

--- a/src/metric/FARCompoundMetric.py
+++ b/src/metric/FARCompoundMetric.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+from src.metric.CompoundMetric import CompoundMetric
+from src.metric.SampleMetricManager import SampleMetricManager
+from src.core.Setupable import SetupMode
+from src.metric.CompoundMetricManager import CompoundMetricManager
+from typing import Any, TYPE_CHECKING
+from src.population.Population import Population
+from src.metric.DatasetSimilaritySampleMetric import DatasetSimilaritySampleMetric
+from src.metric.PopulationSimilaritySampleMetric import PopulationSimilaritySampleMetric
+import numpy as np
+from src.util.AuxUtil import get_file_jar
+import src.metric.MatchingScore as MS
+from tqdm import tqdm
+import matplotlib.pyplot as plt
+
+if TYPE_CHECKING:
+    from src.compound_model.CompoundModelFactory import CompoundModelFactoryContext
+
+FAR_NAME = "FAR"
+DS_VS_DS_FILE_NAME = (
+    lambda ds_name: "_".join([ds_name, "vs", ds_name, "similarity"]) + ".npy"
+)
+
+# SETUP NAMES
+DS_VS_DS_SETUP_NAME = "DATASET_VS_DATASET"
+
+# Threshold constants
+T_MIN = 0
+T_MAX = 10
+T_STEPS = 50
+
+
+class FARCompoundMetric(CompoundMetric):
+    def __init__(
+        self,
+        cmm: CompoundMetricManager,
+        smm: SampleMetricManager,
+    ):
+        super(FARCompoundMetric, self).__init__(FAR_NAME, cmm, smm)
+
+        # Define threshold linspace
+        self._thresholds = self._get_threshold_space()
+
+        # Init storage structure for this metric
+        self._file_jar = get_file_jar()
+        self._far_ds_vs_ds = None
+        self._far = None
+        self._filter_name_dict = dict()
+
+    def reg_setup_modes(self) -> dict[str, SetupMode]:
+        """
+        Return a dictionary declaring all available setup modes.
+
+        The dictionary consist of setup mode names, mapped to SetupMode objects.
+
+        Raises:
+            AssertionError: When DatasetSimilaritySampleMetric
+
+        Returns:
+            dict[str, SetupMode]: All setup modes, and their functionality.
+        """
+        ds_setup_modes = None
+        pop_setup_modes = None
+        for sm in self._smm.get_metric_instances():
+            if isinstance(sm, DatasetSimilaritySampleMetric):
+                ds_setup_modes = sm.reg_setup_modes()
+            elif isinstance(sm, PopulationSimilaritySampleMetric):
+                pop_setup_modes = sm.reg_setup_modes()
+        assert ds_setup_modes is not None
+        assert pop_setup_modes is not None
+
+        # Merge sample metric setup modes
+        sample_metric_setup_modes = pop_setup_modes | ds_setup_modes
+
+        # Define setup mode exclusive for FAR
+        ds_vs_ds_setup_mode = {
+            DS_VS_DS_SETUP_NAME: SetupMode(
+                lambda _: self._setup_dataset_vs_dataset(),
+                self._is_dataset_vs_dataset_ready,
+                required_modes=[setup_name for setup_name in ds_setup_modes.keys()],
+            )
+        }
+
+        # Merge all
+        return sample_metric_setup_modes | ds_vs_ds_setup_mode
+
+    def _setup_dataset_vs_dataset(self):
+        # Calculate the dataset vs dataset similarity
+        sim = DatasetSimilaritySampleMetric.dataset_vs_dataset_similarity(self._dataset)
+
+        # Store result on disk
+        self._file_jar.store_file(
+            DS_VS_DS_FILE_NAME(self._dataset.get_name(self._dataset.get_resolution())),
+            lambda p: np.save(p, sim),
+        )
+
+    def _is_dataset_vs_dataset_ready(self):
+        return self._file_jar.has_file(
+            DS_VS_DS_FILE_NAME(self._dataset.get_name(self._dataset.get_resolution()))
+        )
+
+    def _calc_far(self, similarities: np.ndarray) -> np.ndarray:
+        """
+        Calculates the FAR as a function of thresholds
+
+        Assumes all samples are different identities
+
+        If a similarity is above the threshold, then this sample is considered the same
+        identity with its neighbor, by assumption samples are not same identities.
+        Thus, it is misclassified when they are the same identity.
+        """
+
+        return np.mean(
+            similarities.reshape(similarities.size, 1)
+            > self._thresholds.reshape(1, self._thresholds.shape[0]),
+            0,
+        )
+
+    def _get_threshold_space(self) -> np.ndarray:
+        # TODO: Find a cool way to inferr max/min
+        return np.linspace(T_MIN, T_MAX, T_STEPS)
+
+    def calc(self, filter_bit: int = 1, **parameters: Any) -> Any:
+        """
+        Calculates the false acceptance rate as a function of similarity thresholds.
+
+        Requires a context of other models and populations, this is given from the
+        compound metric manager, be sure to create a `CompoundModelFactoryContext` before
+        calculating FAR.
+
+        Args:
+            filter_bit (int, optional): Filter bit used for filtering. Defaults to 1.
+
+        Raises:
+            FileNotFoundError: When setup with dataset vs dataset has not been performed.
+            AssertionError: When context of other populations are not available.
+
+        Returns:
+            Any: FAR as a function of similarity threshold, formatted as a list with containing a
+                dict with all the FAR combinations (dataset vs dataset, population vs dataset,
+                population vs population).
+        """
+
+        # Get context
+        context = self._cmm.get_context()
+        assert context is not None
+
+        # Dataset vs dataset (Symmetrical)
+        if self._far_ds_vs_ds is None:
+            similarities = self._file_jar.get_file(
+                DS_VS_DS_FILE_NAME(
+                    self._dataset.get_name(self._dataset.get_resolution())
+                ),
+                np.load,
+            )
+            if similarities is None:
+                raise FileNotFoundError(
+                    "Dataset vs dataset similarity not found, run setup first!"
+                )
+
+            self._far_ds_vs_ds = self._calc_far(similarities)
+
+        # Population variables
+        all_ids = self.get_population().get_data().index
+        filtered_ids = list(
+            all_ids[self.get_population().get_filtering_indices(filter_bit)]
+        )
+
+        # Population vs dataset
+        similarities = self._smm.get(
+            [DatasetSimilaritySampleMetric.get_name()],
+            filtered_ids,
+            calc_if_missing=True,
+            **parameters,
+        ).to_numpy()
+        far_pop_vs_ds = self._calc_far(similarities)
+
+        # This population/filter_bit vs this populations/filter_bit (Symmetrical)
+        similarities = self._smm.get(
+            [PopulationSimilaritySampleMetric.get_name()],
+            filtered_ids,
+            filter_bit=filter_bit,
+            **parameters,
+        )
+        try:
+            # Try to get values
+            similarities = similarities.apply(
+                lambda row: row[0][0][filter_bit][0][1], axis=1
+            ).to_numpy()
+        except:
+            # Not calculated for all samples / filter_bits
+
+            # Calc it
+            self._smm.calc(
+                [PopulationSimilaritySampleMetric.get_name()],
+                filtered_ids,
+                filter_bit=filter_bit,
+                **parameters,
+            )
+            similarities = (
+                self._smm.get(
+                    [PopulationSimilaritySampleMetric.get_name()],
+                    filtered_ids,
+                    calc_if_missing=True,
+                    filter_bit=filter_bit,
+                    **parameters,
+                )
+                .apply(lambda row: row[0][0][filter_bit][0][1], axis=1)
+                .to_numpy()
+            )
+        far_pop_vs_pop = {
+            (self._population.get_name(), filter_bit): self._calc_far(similarities)
+        }
+
+        # This population vs populations/filter_bits
+
+        # Get context
+        populations_vs = list(context.populations.values())
+        filter_bits_vs = list(context.filter_bits.values())
+        far_pop_vs_pops = self._population_vs_populations_far(
+            filter_bit, filter_bits_vs, populations_vs
+        )
+
+        # Format result
+        far = dict()
+        cmf_name = list(far_pop_vs_pop.keys())[0]
+        ds_name = self._dataset.get_name(self._dataset.get_resolution())
+        far[cmf_name] = (
+            {
+                (
+                    ds_name,
+                    None,
+                ): far_pop_vs_ds
+            }
+            | far_pop_vs_pop
+            | far_pop_vs_pops
+        )
+        far[ds_name] = {ds_name: self._far_ds_vs_ds}
+
+        # Save results
+        self._far = [far]
+        self._cmf_name = cmf_name
+        self._far_context = context
+
+        return [far]
+
+    def get(self, calc_if_missing: bool = False, **parameters: Any) -> Any:
+        # Check if metric already calculated
+        filter_bit = parameters["filter_bit"] if "filter_bit" in parameters else 1
+        if self._far is not None:
+            if self._far[0][1] == filter_bit:
+                if self._far_context == self._cmm.get_context():
+                    return self._far
+
+        # Check if calculate when missing
+        if calc_if_missing:
+            return self.calc(**parameters)
+
+        else:
+            return None
+
+    def print_result(self) -> None:
+        for name, d in self._far.items():
+            for t_name, far in d.items():
+                print(f"{name}_vs_{t_name}: ", far)
+
+    def plot_result(self) -> None:
+        def _parse_pop_name(name: tuple[str, int]):
+            cm_name = name[0][4:].split("_")
+            filter_name = (
+                self._filter_name_dict[name[1]]
+                if name[1] in self._filter_name_dict
+                else name[1]
+            )
+            return f"{cm_name[0]}, {cm_name[1]}, {filter_name}Filter"
+
+        for name, d in self._far[0].items():
+            for t_name, far in d.items():
+                # ds vs ds
+                if type(name) == str:
+                    name1 = name
+                    name2 = name1
+                    style = "--"
+                # pop vs ds
+                elif t_name[1] is None:
+                    name1 = _parse_pop_name(name)
+                    name2 = t_name[0]
+                    style = "-."
+                # pop vs pop
+                else:
+                    name1 = _parse_pop_name(name)
+                    name2 = _parse_pop_name(t_name)
+                    style = ":"
+
+                # self vs self
+                if name == t_name and type(name) != str:
+                    style = "-"
+
+                plt.plot(self._thresholds, far, style, label=f"{name1} vs {name2}")
+        plt.title("FAR as a function of similarity score threshold")
+        plt.xlabel("Similarity score threshold")
+        plt.ylabel("FAR (False acceptance rate)")
+        plt.yscale("log")
+        plt.legend()
+        plt.show(block=True)
+
+    def _parse_context(
+        self, context: CompoundModelFactoryContext
+    ) -> tuple[list[Population], list[list[int]]]:
+        populations = [population for population in context.populations.values()]
+        filter_bits = [
+            filter_bits_pop for filter_bits_pop in context.filter_bits.values()
+        ]
+        return populations, filter_bits
+
+    def _population_vs_populations_far(
+        self,
+        filter_bit: int,
+        filter_bits_vs: list[list[tuple[int, str]]],
+        populations_vs: list[Population],
+    ) -> dict[tuple[str, int], np.ndarray]:
+        target_pop_name = self._population.get_name()
+        target_pop_data = self._population.get_filtered_data(filter_bit)
+
+        # Fetch samples to calculate for
+        uris = list(target_pop_data[self._population.COLUMN_URI])
+
+        # Project self population
+        target_projections = MS.project_images(uris)
+
+        results = dict()
+        # Loop through all populations
+        for i, population in enumerate(populations_vs):
+            pop_name = population.get_name()
+            pop_data = population.get_data()
+            uris_unfiltered_vs = list(pop_data[population.COLUMN_URI])
+
+            # Project population images
+            sample_unfiltered_projections_vs = MS.project_images(uris_unfiltered_vs)
+
+            # Loop through all filter
+            for filter_bit_vs in filter_bits_vs[i]:
+
+                # Save filter bit and name connection
+                self._filter_name_dict[filter_bit_vs[0]] = filter_bit_vs[1]
+
+                filter_bit_vs = filter_bit_vs[0]
+
+                # Skip self population
+                if pop_name == target_pop_name and filter_bit_vs == filter_bit:
+                    continue
+
+                # Filter population projections
+                filtering = population.get_filtering_indices(filter_bit_vs)
+                sample_projections_vs = sample_unfiltered_projections_vs[filtering]
+
+                # Derive similarity scores and find largest per sample
+                output = np.zeros(target_projections.shape[0], dtype=np.ndarray)
+                for i in tqdm(
+                    range(target_projections.shape[0]),
+                    desc="Calculating similarity scores",
+                ):
+                    similarities = (
+                        target_projections[i, :].dot(sample_projections_vs.T).flatten()
+                    )
+
+                    # Check if similarity score for samples can contain similarity to itself
+                    if pop_name == target_pop_name:
+                        id = target_pop_data.index[i]
+                        sample_index = pop_data[population.COLUMN_URI].index[filtering]
+                        if id in sample_index:
+                            # Do not check similarity with self
+                            similarities[sample_index.get_loc(id)] = -float("inf")
+
+                    output[i] = np.sort(similarities)[-1]
+
+                # Calc far to save memory
+                results[(pop_name, filter_bit_vs)] = self._calc_far(output)
+
+        return results

--- a/src/metric/FIDCompoundMetric.py
+++ b/src/metric/FIDCompoundMetric.py
@@ -152,8 +152,7 @@ class FIDCompoundMetric(CompoundMetric):
 
         Args:
             filter_bit (int, optional): Filter bit used to select a subset of the
-                population. Filter bit is defined by the order in FilterRegistry. For example,
-                the first filter corresponds to filter bit 1. EDefaults to 1 (IdentityFilter).
+                population. Defaults to 1 (IdentityFilter).
             calc_mode (str, optional): Either "clean", "legacy_tensorflow, or "legacy_pytorch".
                 This decides how the FID score should be calculated, i.e., using clean-fid,
                 regular tensorflow implementation, or pytorch implementation. Default is "clean" (clean-fid).

--- a/src/metric/LSCompoundMetric.py
+++ b/src/metric/LSCompoundMetric.py
@@ -169,8 +169,7 @@ class LSCompoundMetric(CompoundMetric):
 
         Args:
             filter_bit (int, optional): Filter bit used to select a subset of the
-                population. Filter bit is defined by the order in FilterRegistry. For example,
-                the first filter corresponds to filter bit 1. Defaults to 1 (IdentityFilter).
+                population. Defaults to 1 (IdentityFilter).
 
         Returns:
             Any: LS of the population.

--- a/src/metric/PPLCompoundMetric.py
+++ b/src/metric/PPLCompoundMetric.py
@@ -94,8 +94,7 @@ class PPLCompoundMetric(CompoundMetric):
         #! Note that there must be at least two samples in the population.
         Args:
             filter_bit (int, optional): Filter bit used to select a subset of the
-                population. Filter bit is defined by the order in FilterRegistry. For example,
-                the first filter corresponds to filter bit 1. Defaults to 1 (IdentityFilter).
+                population. Defaults to 1 (IdentityFilter).
             batch_size (int, optional): Batch size used to calculate the PPL.
                 Note that batch size must be even!
                 Defaults to `BATCH_SIZE`.

--- a/src/metric/PrecisionCompoundMetric.py
+++ b/src/metric/PrecisionCompoundMetric.py
@@ -59,8 +59,7 @@ class PrecisionCompoundMetric(CompoundMetric):
 
         Args:
             filter_bit (int, optional): Filter bit used to select a subset of the
-                population. Filter bit is defined by the order in FilterRegistry. For example,
-                the first filter corresponds to filter bit 1. Defaults to 1 (IdentityFilter).
+                population. Defaults to 1 (IdentityFilter).
             batch_size (int, optional): The batch size to use when projecting images
                 through the VGG16-network on the GPU. Defaults to `BATCH_SIZE`.
             dist_calc_batch_size (int, optional): The batch size to use when calculating

--- a/src/metric/RecallCompoundMetric.py
+++ b/src/metric/RecallCompoundMetric.py
@@ -59,8 +59,7 @@ class RecallCompoundMetric(CompoundMetric):
 
         Args:
             filter_bit (int, optional): Filter bit used to select a subset of the
-                population. Filter bit is defined by the order in FilterRegistry. For example,
-                the first filter corresponds to filter bit 1. Defaults to 1 (IdentityFilter).
+                population. Defaults to 1 (IdentityFilter).
             batch_size (int, optional): The batch size to use when projecting images
                 through the VGG16-network on the GPU. Defaults to `BATCH_SIZE`.
             dist_calc_batch_size (int, optional): The batch size to use when calculating

--- a/src/population/Population.py
+++ b/src/population/Population.py
@@ -3,10 +3,9 @@ from pathlib import Path
 import pandas as pd
 import numpy as np
 from typing import Union, Type, TYPE_CHECKING
-
 from src.util.FileJar import FileJar
 from src.filter.Filter import Filter
-from src.filter.FilterRegistry import FilterRegistry
+
 
 if TYPE_CHECKING:
     from src.metric.SampleMetricManager import SampleMetricManager
@@ -204,8 +203,7 @@ class Population:
                 on a per-row basis.
             uris (list[str]): Paths leading to the sample images.
             filter_bitmaps (list[int]): Bitmaps describing what filters the samples have
-                passed. The order of the bits are analogous to the order of filter
-                appearance in the FilterRegistry.
+                passed.
             append (bool, optional): If `True`, the samples will be appended onto the
                 existing population. Otherwise, all current samples will be replaced.
                 Defaults to True.
@@ -325,8 +323,7 @@ class Population:
                 the `attributes` input to become `latent_code`.
             uri (str): A path leading to the sample image.
             filter_bitmap (int, optional): A bitmap describing what filters this
-                sample has passed. The order of the bits are analogous to the order of
-                filter appearance in the FilterRegistry. Defaults to 0.
+                sample has passed. Defaults to 0.
             append (bool, optional): If `True`, this sample will be appended onto the
                 existing population. Otherwise, all current samples will be replaced.
                     Defaults to True.
@@ -427,8 +424,6 @@ class Population:
 
         Args:
             mask (int): A bitmap with '1' for all filters that the samples must pass.
-                The order of the bits are analogous to the order of filters
-                in the FilterRegistry.
 
         Returns:
             pd.DataFrame: The filtered samples.
@@ -447,8 +442,6 @@ class Population:
 
         Args:
             mask (int): A bitmap with '1' for all filters that the samples must pass.
-                The order of the bits are analogous to the order of filters
-                in the FilterRegistry
 
         Returns:
             list[bool]: The filtering indices as a boolean list, True if indices passed,
@@ -479,7 +472,7 @@ class Population:
 
         # Update bitmap for the passing samples
         # Set filter bit to 1 in bitmap
-        bit = filter.get_bit(FilterRegistry)
+        bit = filter.get_bit()
         ind = filter.apply(smm)
         self._data[self.COLUMN_FILTER_BITMAP][ind] = self._data[
             self.COLUMN_FILTER_BITMAP


### PR DESCRIPTION
also:
- context class in compound model factory
- context related function in compound metric manager
- filter bit refactor, get_bit is now a static method function
- population similarity metric refactored such that results are stored for a specific filter bit
- Various small fixes to make FAR and the newly refactored population similarity work properly

note:
- filter bit is no longer associated with the order in filter registry

Closes #141 