### PR TITLE
enhance: center crop in partial fc transform

### DIFF
--- a/src/metric/MatchingScore.py
+++ b/src/metric/MatchingScore.py
@@ -82,6 +82,7 @@ def _get_partial_fc_transform() -> T.Compose:
         [
             T.ToTensor(),
             T.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+            T.CenterCrop(192),
             T.Resize(112),
         ]
     )


### PR DESCRIPTION
Since this changes of partial fc work the following files should be removed in the auxiliary directory:
- FFHQ_256_vs_FFHQ_256_similarity.npy
- partial_fc_proj_FFHQ_256.npy

FAR results and filtering based on similarity scores should be recalculated.
 